### PR TITLE
Fix Typos and Add Region Restrictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,10 @@ from other systems.
 ### Run Template
 
     export PREFIX=mycompany
-    aws cloudfromation create-stack \
+    aws cloudformation create-stack \
+       --stack-name adobe-analytics-data-lake \
        --template-body file://adobe-analytics-data-lake.yaml \
-       --capabilities CAPABILITY_NAME_IAM
+       --capabilities CAPABILITY_NAMED_IAM \
        --parameters \
            ParameterKey=AdobeAnalyticsDataFeedS3BucketName,ParameterValue=$PREFIX-adobe-analytics-data-feed \
            ParameterKey=AdobeAnalyticsDataLakeS3BucketName,ParameterValue=$PREFIX-adobe-analytics-data-lake \

--- a/README.md
+++ b/README.md
@@ -33,9 +33,12 @@ from other systems.
 
 ## Setup
 
+Make sure that you set your CLI's default region to one of the supported ones listed [here](https://marketing.adobe.com/resources/help/en_US/reference/r_feed-destination.html). Alternatively you can use the [--region option](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-options.html) as shown in the code below.
+
 ### Run Template
 
     export PREFIX=mycompany
+    export REGION=myregion
     aws cloudformation create-stack \
        --stack-name adobe-analytics-data-lake \
        --template-body file://adobe-analytics-data-lake.yaml \
@@ -46,7 +49,8 @@ from other systems.
            ParameterKey=AdobeAnalyticsGlueJobScriptsS3BucketName,ParameterValue=$PREFIX-glue-scripts \
            ParameterKey=GlueDataLakeDatabaseName,ParameterValue=adobe-analytics-data-lake \
            ParameterKey=AdobeAnalyticsGlueJobName,ParameterValue=adobe-analytics-data-feed-to-lake \
-           ParameterKey=RedshiftSpectrumRoleName,ParameterValue=redshift-spectrum-adobe-analytics
+           ParameterKey=RedshiftSpectrumRoleName,ParameterValue=redshift-spectrum-adobe-analytics\
+       --region $REGION
 
 ### Upload the Glue Job Python script
 


### PR DESCRIPTION
This PR fixes a few typos in the cloudformation command. It also adds more info for selecting an Adobe supported region.